### PR TITLE
Fix unterminated string literal

### DIFF
--- a/FormatStyles And You.playground/Pages/3.4 Verbatim Date Style.xcplaygroundpage/Contents.swift
+++ b/FormatStyles And You.playground/Pages/3.4 Verbatim Date Style.xcplaygroundpage/Contents.swift
@@ -14,7 +14,7 @@ let twosdayDateComponents = DateComponents(
 let twosday = Calendar(identifier: .gregorian).date(from: twosdayDateComponents)!
 
 let verbatim = Date.VerbatimFormatStyle(
-    format: "Today is Twoesday \(month: .defaultDigits) \(day: .defaultDigits) \(hour: .twoDigits(clock: .twentyFourHour, hourCycle: .oneBased)):\(minute: .twoDigits),
+    format: "Today is Twoesday \(month: .defaultDigits) \(day: .defaultDigits) \(hour: .twoDigits(clock: .twentyFourHour, hourCycle: .oneBased)):\(minute: .twoDigits)",
     timeZone: TimeZone.current,
     calendar: .current
 )


### PR DESCRIPTION
Currently, this page fails with the following error:

```
error: error while processing module import: 3.4 Verbatim Date Style.xcplaygroundpage:18:13: unterminated string literal
    format: "Today is Twoesday \(month: .defaultDigits) \(day: .defaultDigits) \(hour: .twoDigits(clock: .twentyFourHour, hourCycle: .oneBased)):\(minute: .twoDigits),
```